### PR TITLE
Update to lastest manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@oclif/plugin-autocomplete": "3.0.13",
     "@oclif/plugin-warn-if-update-available": "^3.1.6",
     "@subsquid/commands": "^2.3.1",
-    "@subsquid/manifest": "^0.0.1-beta.17",
+    "@subsquid/manifest": "^1.0.0-beta.11",
     "@subsquid/manifest-expr": "^0.0.1",
     "@types/fast-levenshtein": "^0.0.4",
     "@types/lodash": "^4.17.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@subsquid/cli",
   "description": "squid cli tool",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "license": "GPL-3.0-or-later",
   "repository": "git@github.com:subsquid/squid-cli.git",
   "publishConfig": {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { promisify } from 'util';
 
 import { Args, Flags, ux as CliUx } from '@oclif/core';
-import { ManifestValue } from '@subsquid/manifest';
+import { Manifest } from '@subsquid/manifest';
 import chalk from 'chalk';
 import { globSync } from 'glob';
 import ignore from 'ignore';
@@ -27,7 +27,7 @@ const SQUID_PATH_DESC = [
 export function resolveManifest(
   localPath: string,
   manifestPath: string,
-): { error: string } | { buildDir: string; squidDir: string; manifest: ManifestValue } {
+): { error: string } | { buildDir: string; squidDir: string; manifest: Manifest } {
   try {
     const { squidDir, manifest } = loadManifestFile(localPath, manifestPath);
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,7 +1,8 @@
 import { Help as OclifHelp, ux as CliUx } from '@oclif/core';
-import chalk from 'chalk';
-import { getSquidCommands } from './utils';
 import * as Interfaces from '@oclif/core/lib/interfaces';
+import chalk from 'chalk';
+
+import { getSquidCommands } from './utils';
 
 const TABLE_OPTIONS = {
   'no-header': true,
@@ -74,7 +75,9 @@ export default class Help extends OclifHelp {
       }));
   }
 
-  static getVisibleCloudCommands(config: Interfaces.Config): { name: string; description?: string; aliases: string[] }[] {
+  static getVisibleCloudCommands(
+    config: Interfaces.Config,
+  ): { name: string; description?: string; aliases: string[] }[] {
     const aliases = new Set<string>();
 
     return config.commands

--- a/src/hooks/command_not_found.ts
+++ b/src/hooks/command_not_found.ts
@@ -1,16 +1,17 @@
 import { Hook, toConfiguredId } from '@oclif/core';
-import { getSquidCommands } from '../utils';
 import { run as squidCommandRun } from '@subsquid/commands/lib/run';
 import chalk from 'chalk';
-import { minBy } from 'lodash';
 import Levenshtein from 'fast-levenshtein';
+import { minBy } from 'lodash';
+
 import Help from '../help';
+import { getSquidCommands } from '../utils';
 
 function closestCommand(cmd: string, commands: string[]) {
   return minBy(commands, (c) => Levenshtein.get(cmd, c))!;
 }
 
-const hook: Hook<'command_not_found'> = async function ({ id, argv, config}) {
+const hook: Hook<'command_not_found'> = async function ({ id, argv, config }) {
   const squidCmdConfig = await getSquidCommands();
   if (squidCmdConfig?.commands?.[id]) {
     process.exit(await squidCommandRun(squidCmdConfig, id, (argv || []).slice(1)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,7 +1337,7 @@ __metadata:
     "@oclif/plugin-autocomplete": "npm:3.0.13"
     "@oclif/plugin-warn-if-update-available": "npm:^3.1.6"
     "@subsquid/commands": "npm:^2.3.1"
-    "@subsquid/manifest": "npm:^0.0.1-beta.17"
+    "@subsquid/manifest": "npm:^1.0.0-beta.11"
     "@subsquid/manifest-expr": "npm:^0.0.1"
     "@types/async-retry": "npm:^1.4.8"
     "@types/blessed": "npm:^0.1.25"
@@ -1436,14 +1436,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subsquid/manifest@npm:^0.0.1-beta.17":
-  version: 0.0.1-beta.17
-  resolution: "@subsquid/manifest@npm:0.0.1-beta.17"
+"@subsquid/manifest@npm:^1.0.0-beta.11":
+  version: 1.0.0-beta.11
+  resolution: "@subsquid/manifest@npm:1.0.0-beta.11"
   dependencies:
+    "@subsquid/manifest-expr": "npm:^0.0.1"
     joi: "npm:^17.12.0"
     js-yaml: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/5ef504f4c2e12c3f4648f46dae7042d8a8c75c90aa35f2aad1ec873eda040ebba9356820f9b2a93908689804ec87b6b50ef9c8933798ad9c2d17b028fb00b8ab
+  checksum: 10c0/6ced44b1943c90e46557d56654da2dbedf28d83b0d4b0e2201effc33d9a4501ce433320593640ad92e29d9ef1ce381c7542250afd10d9f85b9b3967a50061748
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`0.0.1` version doesn't contain newest `squid_manifest` updates. Also in lastest version @subsquid/manifest have differend interface for parsing manifest.

1. `@subsquid/manifest@^0.0.1-beta.17` -> `@subsquid/manifest@^1.0.0-beta.11`
2. Processing of `Manifest.parse` [changed](https://github.com/subsquid/squid-cli/commit/7ff7f6d591baa4c7470e08a7592f7f119e7b7f59#diff-555cc3eee1fb60fa9669028c26f9c51001e139c6afde03920f60b1b04aec6668L101-R110)