### PR TITLE
docs: factual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,75 @@
-# @subsquid/cli
+# Squid CLI (`sqd`)
 
-[![npm version](https://badge.fury.io/js/@subsquid%2Fcli.svg)](https://badge.fury.io/js/@subsquid%2Fcli)
+[![npm version](https://badge.fury.io/js/@subsquid%2Fcli.svg)](https://www.npmjs.com/package/@subsquid/cli)
 
-`sqd(1)` tool for [squid project](https://docs.sqd.dev/en/sdk) management.
+`@subsquid/cli` is the command line tool for building and deploying Squid SDK blockchain indexers. It installs a single `sqd` binary that scaffolds a new squid project, runs it locally, and deploys and manages squids in [SQD Cloud](https://docs.sqd.dev/en/cloud).
+
+It is part of [SQD](https://sqd.dev), an open data platform for Web3. A squid is an indexer built with the Squid SDK that extracts onchain data into a queryable store.
 
 ## Installation
 
-We recommend installing squid CLI globally:
+Install the CLI globally with npm:
 
-`npm i -g @subsquid/cli`
+```bash
+npm i -g @subsquid/cli
+```
 
-For a full `sqd` command reference, see the [Doc page](https://docs.sqd.dev/en/sdk)
+This adds the `sqd` command to your `PATH`. Check the version with:
+
+```bash
+sqd --version
+```
+
+## Usage
+
+Run `sqd --help` to list all commands, or `sqd <command> --help` for the flags and examples of a specific command.
+
+A typical workflow:
+
+```bash
+# Scaffold a new squid project from a template or GitHub repo
+sqd init my-squid
+
+# Run a squid project locally
+sqd run .
+
+# Log in to SQD Cloud with an API key
+sqd auth -k <your-api-key>
+
+# Deploy a new squid or update an existing one in the Cloud
+sqd deploy .
+```
+
+## Commands
+
+The CLI is built with [oclif](https://oclif.io). The commands below come from the source in `src/commands`.
+
+| Command | Description |
+| --- | --- |
+| `sqd init` | Set up a new squid project from a template or GitHub repo |
+| `sqd run` | Run a squid project locally |
+| `sqd auth` | Log in to the Cloud |
+| `sqd whoami` | Show the user details for the current Cloud account |
+| `sqd deploy` | Deploy a new or update an existing squid in the Cloud |
+| `sqd list` | List squids deployed to the Cloud |
+| `sqd view` | View information about a squid |
+| `sqd logs` | Fetch logs from a squid deployed to the Cloud |
+| `sqd restart` | Restart a squid deployed to the Cloud |
+| `sqd remove` (`rm`) | Remove a squid deployed to the Cloud |
+| `sqd prod` | Assign the canonical production API alias for a squid in the Cloud |
+| `sqd explorer` | Open a visual explorer for Cloud deployments |
+| `sqd docs` | Open the docs in a browser |
+| `sqd tags add` / `tags remove` | Add or remove a tag on a squid |
+| `sqd secrets set` / `secrets list` / `secrets remove` | Manage organization secrets in the Cloud |
+| `sqd gateways list` | List available gateways (data sources for a squid) |
+| `sqd profiles use` / `profiles list` / `profiles remove` | Manage saved CLI profiles |
+
+## Documentation
+
+- CLI reference: https://docs.sqd.dev/squid-cli/
+- SQD Cloud: https://docs.sqd.dev/en/cloud
+- Squid SDK: https://docs.sqd.dev/en/sdk
+
+## License
+
+GPL-3.0-or-later. See `package.json` for details.


### PR DESCRIPTION
Expands the README from a 3-line stub into a factual command reference for the \`sqd\` CLI.

## What I confirmed (and from which files)
- **Package identity** (\`package.json\`): name \`@subsquid/cli\`, binary \`sqd\` (\`bin.sqd\` -> \`./bin/run.js\`), built with oclif (\`oclif\` config block, \`@oclif/core\` dependency), license \`GPL-3.0-or-later\`.
- **Purpose**: scaffold, run locally, and deploy/manage Squid SDK indexers ("squids") in SQD Cloud. Derived from the command \`static description\` strings in \`src/commands\`.
- **Command list and descriptions** taken verbatim from the source:
  - \`src/commands/init.ts\`, \`run.ts\`, \`auth.ts\`, \`whoami.ts\`, \`deploy.ts\`, \`list.ts\`, \`view.ts\`, \`logs.ts\`, \`restart.ts\`, \`remove.ts\` (alias \`rm\`), \`prod.ts\`, \`explorer.ts\`, \`docs.ts\`.
  - Subcommands: \`tags/add.ts\`, \`tags/remove.ts\`, \`secrets/set.ts\`, \`secrets/list.ts\`, \`secrets/remove.ts\`, \`gateways/list.ts\`, \`profiles/use.ts\`, \`profiles/list.ts\`, \`profiles/remove.ts\`.
- **Install command** (\`npm i -g @subsquid/cli\`) matches the existing README and the \`warn-if-update-available\` message in \`package.json\`.
- The \`auth\` example flag \`-k <api-key>\` comes from \`auth.ts\` examples.

No invented features, chains, or performance claims. Plain style, no em dashes, "onchain" one word.

## Links verified 200
- https://docs.sqd.dev/squid-cli/ (redirects to the CLI reference)
- https://docs.sqd.dev/en/cloud
- https://docs.sqd.dev/en/sdk
- https://sqd.dev
- https://registry.npmjs.org/@subsquid/cli (npm page 403s to curl but is valid; registry returns 200)
- npm badge and https://oclif.io both 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)